### PR TITLE
DIR-7041 updated unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,13 @@ http {
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval' blob:; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self';";
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # proxy /wp-content/uploads/ -> s3 bucket
@@ -92,8 +97,13 @@ http {
         server_name www.alcohol.org;
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         return 301 https://alcohol.org$request_uri;


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/DIR-7041

Brief Description:
DIR-7041 updated unserved file types

Example Links
https://staging.alcohol.org/test.env
https://staging.alcohol.org/test.aspx
https://staging.alcohol.org/test.env.aspx
https://staging.alcohol.org/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.alcohol.org/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/alcohol-org-nginx/assets/86256771/a4b3a79e-1a6c-485a-9bb3-5a3021f88b6d)
