### PR TITLE
DIR-4869 fix destination url so that it does not 404

### DIFF
--- a/nginx/conf.d/redirects/redirects.conf
+++ b/nginx/conf.d/redirects/redirects.conf
@@ -83,7 +83,7 @@ rewrite ^/mixing-with/opioids/?$ https://$host/ permanent;
 rewrite ^/effects/studying-while-drinking/?$ https://$host/health-effects/ permanent;
 rewrite ^/effects/scuba-diving/?$ https://$host/health-effects/ permanent;
 rewrite ^/effects/on-your-memory/?$ https://$host/health-effects/memory-loss/ permanent;
-rewrite ^/effects/gout/?$ https://$host/effects/alcohol-and-gout/ permanent;
+rewrite ^/effects/gout/?$ https://$host/health-effects/alcohol-and-gout/ permanent;
 rewrite ^/effects/fighting-drunk/?$ https://$host/health-effects/inhibitions/ permanent;
 rewrite ^/effects/fatty-liver-disease/?$ https://$host/health-effects/liver-disease-and-alcohol/ permanent;
 rewrite ^/effects/epilepsy-and-seizures/?$ https://$host/detoxification/ permanent;


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/DIR-4869

Description:
Update destination URL for /effects/gout/ redirect so that it does not 404

Example:
https://staging.alcohol.org/effects/gout/ redirects to /health-effects/alcohol-and-gout/ 